### PR TITLE
Include named chunk group data in bundle data

### DIFF
--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -1,9 +1,11 @@
 import { BundleData } from '../../types/BundleData';
 import { Stats } from '../../types/Stats';
 import { deriveGraph } from './deriveGraph';
+import { deriveChunkGroupData } from './deriveChunkGroupData';
 
 export function deriveBundleData(stats: Stats): BundleData {
     return {
         graph: deriveGraph(stats),
+        chunkGroups: deriveChunkGroupData(stats),
     };
 }

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -1,94 +1,9 @@
-import { BundleData, ModuleGraph, ModuleGraphNode } from '../../types/BundleData';
-import { Stats, Module, Reason } from '../../types/Stats';
-import ModuleIdToNameMap from './ModuleIdToNameMap';
-import NamedChunkGroupLookupMap from './NamedChunkGroupLookupMap';
+import { BundleData } from '../../types/BundleData';
+import { Stats } from '../../types/Stats';
+import { deriveGraph } from './deriveGraph';
 
 export function deriveBundleData(stats: Stats): BundleData {
     return {
-        graph: generateGraph(stats),
+        graph: deriveGraph(stats),
     };
-}
-
-function generateGraph(stats: Stats): ModuleGraph {
-    const moduleIdToNameMap = new ModuleIdToNameMap(stats);
-    const ncgLookup = new NamedChunkGroupLookupMap(stats);
-
-    let graph: ModuleGraph = {};
-
-    for (let module of stats.modules) {
-        processModule(module, graph, moduleIdToNameMap, ncgLookup);
-    }
-
-    return graph;
-}
-
-export function processModule(
-    module: Module,
-    graph: ModuleGraph,
-    moduleIdToNameMap: ModuleIdToNameMap,
-    ncgLookup: NamedChunkGroupLookupMap
-) {
-    // Modules marked as ignored don't get bundled, so we can ignore them too
-    if (module.identifier.startsWith('ignored ')) {
-        return;
-    }
-
-    // Precalculate named chunk groups since they are the same for all submodules
-    const namedChunkGroups = ncgLookup.getNamedChunkGroups(module.chunks);
-
-    if (!module.modules) {
-        // This is just an individual module, so we can add it to the graph as-is
-        addModuleToGraph(graph, {
-            name: module.name,
-            parents: getParents(module.reasons, moduleIdToNameMap),
-            namedChunkGroups,
-            size: module.size,
-        });
-    } else {
-        // The module is the amalgamation of multiple scope hoisted modules, so we add each of
-        // them individually.
-
-        // Assume the first hoisted module acts as the primary module
-        const primaryModule = module.modules[0];
-        addModuleToGraph(graph, {
-            name: primaryModule.name,
-            parents: getParents(module.reasons, moduleIdToNameMap),
-            containsHoistedModules: true,
-            namedChunkGroups,
-            size: primaryModule.size,
-        });
-
-        // Other hoisted modules are parented to the primary module
-        for (let i = 1; i < module.modules.length; i++) {
-            const hoistedModule = module.modules[i];
-            addModuleToGraph(graph, {
-                name: hoistedModule.name,
-                parents: [primaryModule.name],
-                namedChunkGroups,
-                size: hoistedModule.size,
-            });
-        }
-    }
-}
-
-export function getParents(reasons: Reason[], moduleIdToNameMap: ModuleIdToNameMap) {
-    // Start with the module ID for each reason
-    let moduleIds = reasons.map(r => r.moduleId);
-
-    // Filter out nulls (this happens for entry point modules)
-    moduleIds = moduleIds.filter(p => p != null);
-
-    // Filter out duplicates (this happens due to scope hoisting)
-    moduleIds = [...new Set(moduleIds)];
-
-    // Map module IDs to module names
-    return moduleIds.map(moduleId => moduleIdToNameMap.get(moduleId));
-}
-
-function addModuleToGraph(graph: ModuleGraph, moduleNode: ModuleGraphNode) {
-    if (graph[moduleNode.name]) {
-        throw new Error(`Module already exists in graph: ${moduleNode.name}`);
-    }
-
-    graph[moduleNode.name] = moduleNode;
 }

--- a/src/api/deriveBundleData/deriveChunkGroupData.ts
+++ b/src/api/deriveBundleData/deriveChunkGroupData.ts
@@ -1,0 +1,42 @@
+import { Stats } from '../../types/Stats';
+import { ChunkGroupData } from '../../types/BundleData';
+
+export function deriveChunkGroupData(stats: Stats) {
+    const chunkGroupData: ChunkGroupData = {};
+    const assetSizeMap = getAssetSizeMap(stats);
+
+    // Process each named chunk group
+    for (let chunkGroupName of Object.keys(stats.namedChunkGroups)) {
+        const chunkGroup = stats.namedChunkGroups[chunkGroupName];
+
+        let size = 0;
+        let assets: string[] = [];
+        let ignoredAssets: string[] = [];
+
+        // Process each asset in the chunk group
+        for (let asset of chunkGroup.assets) {
+            // Source maps don't count towards size
+            if (asset.endsWith('.map')) {
+                ignoredAssets.push(asset);
+            } else {
+                assets.push(asset);
+                size += assetSizeMap.get(asset);
+            }
+        }
+
+        chunkGroupData[chunkGroupName] = { size, assets, ignoredAssets };
+    }
+
+    return chunkGroupData;
+}
+
+// Create a map of asset name -> asset size
+function getAssetSizeMap(stats: Stats) {
+    const assetSizeMap = new Map<string, number>();
+
+    for (let asset of stats.assets) {
+        assetSizeMap.set(asset.name, asset.size);
+    }
+
+    return assetSizeMap;
+}

--- a/src/api/deriveBundleData/deriveGraph.ts
+++ b/src/api/deriveBundleData/deriveGraph.ts
@@ -1,0 +1,88 @@
+import { ModuleGraph, ModuleGraphNode } from '../../types/BundleData';
+import { Stats, Module, Reason } from '../../types/Stats';
+import ModuleIdToNameMap from './ModuleIdToNameMap';
+import NamedChunkGroupLookupMap from './NamedChunkGroupLookupMap';
+
+export function deriveGraph(stats: Stats): ModuleGraph {
+    const moduleIdToNameMap = new ModuleIdToNameMap(stats);
+    const ncgLookup = new NamedChunkGroupLookupMap(stats);
+
+    let graph: ModuleGraph = {};
+
+    for (let module of stats.modules) {
+        processModule(module, graph, moduleIdToNameMap, ncgLookup);
+    }
+
+    return graph;
+}
+
+export function processModule(
+    module: Module,
+    graph: ModuleGraph,
+    moduleIdToNameMap: ModuleIdToNameMap,
+    ncgLookup: NamedChunkGroupLookupMap
+) {
+    // Modules marked as ignored don't get bundled, so we can ignore them too
+    if (module.identifier.startsWith('ignored ')) {
+        return;
+    }
+
+    // Precalculate named chunk groups since they are the same for all submodules
+    const namedChunkGroups = ncgLookup.getNamedChunkGroups(module.chunks);
+
+    if (!module.modules) {
+        // This is just an individual module, so we can add it to the graph as-is
+        addModuleToGraph(graph, {
+            name: module.name,
+            parents: getParents(module.reasons, moduleIdToNameMap),
+            namedChunkGroups,
+            size: module.size,
+        });
+    } else {
+        // The module is the amalgamation of multiple scope hoisted modules, so we add each of
+        // them individually.
+
+        // Assume the first hoisted module acts as the primary module
+        const primaryModule = module.modules[0];
+        addModuleToGraph(graph, {
+            name: primaryModule.name,
+            parents: getParents(module.reasons, moduleIdToNameMap),
+            containsHoistedModules: true,
+            namedChunkGroups,
+            size: primaryModule.size,
+        });
+
+        // Other hoisted modules are parented to the primary module
+        for (let i = 1; i < module.modules.length; i++) {
+            const hoistedModule = module.modules[i];
+            addModuleToGraph(graph, {
+                name: hoistedModule.name,
+                parents: [primaryModule.name],
+                namedChunkGroups,
+                size: hoistedModule.size,
+            });
+        }
+    }
+}
+
+export function getParents(reasons: Reason[], moduleIdToNameMap: ModuleIdToNameMap) {
+    // Start with the module ID for each reason
+    let moduleIds = reasons.map(r => r.moduleId);
+
+    // Filter out nulls (this happens for entry point modules)
+    moduleIds = moduleIds.filter(p => p != null);
+
+    // Filter out duplicates (this happens due to scope hoisting)
+    moduleIds = [...new Set(moduleIds)];
+
+    // Map module IDs to module names
+    return moduleIds.map(moduleId => moduleIdToNameMap.get(moduleId));
+}
+
+function addModuleToGraph(graph: ModuleGraph, moduleNode: ModuleGraphNode) {
+    if (graph[moduleNode.name]) {
+        throw new Error(`Module already exists in graph: ${moduleNode.name}`);
+    }
+
+    graph[moduleNode.name] = moduleNode;
+}

--- a/src/types/BundleData.ts
+++ b/src/types/BundleData.ts
@@ -1,5 +1,6 @@
 export interface BundleData {
     graph: ModuleGraph;
+    chunkGroups: ChunkGroupData;
 }
 
 export interface ModuleGraph {
@@ -12,4 +13,14 @@ export interface ModuleGraphNode {
     name: string;
     parents: string[];
     size: number;
+}
+
+export interface ChunkGroupData {
+    [chunkGroupName: string]: ChunkGroupRecord;
+}
+
+export interface ChunkGroupRecord {
+    size: number;
+    assets: string[];
+    ignoredAssets: string[];
 }

--- a/test/api/deriveChunkGroupDataTests.ts
+++ b/test/api/deriveChunkGroupDataTests.ts
@@ -1,0 +1,61 @@
+import { deriveChunkGroupData } from '../../src/api/deriveBundleData/deriveChunkGroupData';
+
+describe('deriveChunkGroupData', () => {
+    const assets = [{ name: 'asset1.js', size: 1 }, { name: 'asset2.js', size: 2 }];
+
+    it('produces data for each named chunk group', () => {
+        // Arrange
+        const stats: any = {
+            namedChunkGroups: {
+                chunkGroup1: { assets: [] },
+                chunkGroup2: { assets: [] },
+            },
+            assets,
+        };
+
+        // Act
+        const chunkGroupData = deriveChunkGroupData(stats);
+
+        // Assert
+        expect(chunkGroupData).toEqual({
+            chunkGroup1: { size: 0, assets: [], ignoredAssets: [] },
+            chunkGroup2: { size: 0, assets: [], ignoredAssets: [] },
+        });
+    });
+
+    it('accounts for each asset in a chunk group', () => {
+        // Arrange
+        const stats: any = {
+            namedChunkGroups: {
+                chunkGroup1: { assets: ['asset1.js', 'asset2.js'] },
+            },
+            assets,
+        };
+
+        // Act
+        const chunkGroupData = deriveChunkGroupData(stats);
+
+        // Assert
+        expect(chunkGroupData).toEqual({
+            chunkGroup1: { size: 3, assets: ['asset1.js', 'asset2.js'], ignoredAssets: [] },
+        });
+    });
+
+    it('ignores sourcemap assets', () => {
+        // Arrange
+        const stats: any = {
+            namedChunkGroups: {
+                chunkGroup1: { assets: ['asset1.js', 'asset1.js.map'] },
+            },
+            assets,
+        };
+
+        // Act
+        const chunkGroupData = deriveChunkGroupData(stats);
+
+        // Assert
+        expect(chunkGroupData).toEqual({
+            chunkGroup1: { size: 1, assets: ['asset1.js'], ignoredAssets: ['asset1.js.map'] },
+        });
+    });
+});

--- a/test/api/deriveGraphTests.ts
+++ b/test/api/deriveGraphTests.ts
@@ -1,4 +1,4 @@
-import { processModule, getParents } from '../../src/api/deriveBundleData/deriveBundleData';
+import { processModule, getParents } from '../../src/api/deriveBundleData/deriveGraph';
 
 const moduleIdToNameMap: any = new Map([[1, 'module1'], [2, 'module2'], [3, 'module3']]);
 const namedChunkGroupLookupMap: any = { getNamedChunkGroups: () => ['chunkGroup1'] };


### PR DESCRIPTION
This adds data about named chunk groups to bundle data, including the net size of the chunk group and the assets it includes.  (It filters out source maps which are not relevant when it comes to loading a web app.)