### PR TITLE
Include chunk group size changes in diff and report

### DIFF
--- a/src/api/diff/diff.ts
+++ b/src/api/diff/diff.ts
@@ -1,8 +1,8 @@
 import { BundleData } from '../../types/BundleData';
 import { Stats } from '../../types/Stats';
 import { deriveBundleData } from '../deriveBundleData/deriveBundleData';
-// import diffGraph from './diffGraph';
-// import { EnhancedModuleGraph } from './EnhancedModuleGraph';
+import diffGraph from './diffGraph';
+import { EnhancedModuleGraph } from './EnhancedModuleGraph';
 import diffChunkGroups from './diffChunkGroups';
 
 export function diff(baseline: BundleData | Stats, comparison: BundleData | Stats) {
@@ -14,10 +14,11 @@ export function diff(baseline: BundleData | Stats, comparison: BundleData | Stat
     const results = diffChunkGroups(baseline, comparison);
 
     // Diff the graph
-    // let results = diffGraph(
-    //     new EnhancedModuleGraph(baseline.graph),
-    //     new EnhancedModuleGraph(comparison.graph)
-    // );
+    diffGraph(
+        new EnhancedModuleGraph(baseline.graph),
+        new EnhancedModuleGraph(comparison.graph),
+        results
+    );
 
     return results;
 }

--- a/src/api/diff/diff.ts
+++ b/src/api/diff/diff.ts
@@ -1,19 +1,23 @@
 import { BundleData } from '../../types/BundleData';
 import { Stats } from '../../types/Stats';
 import { deriveBundleData } from '../deriveBundleData/deriveBundleData';
-import diffGraph from './diffGraph';
-import { EnhancedModuleGraph } from './EnhancedModuleGraph';
+// import diffGraph from './diffGraph';
+// import { EnhancedModuleGraph } from './EnhancedModuleGraph';
+import diffChunkGroups from './diffChunkGroups';
 
 export function diff(baseline: BundleData | Stats, comparison: BundleData | Stats) {
     // Derive bundle data if necessary
     baseline = getBundleData(baseline);
     comparison = getBundleData(comparison);
 
+    // Diff named chunk groups
+    const results = diffChunkGroups(baseline, comparison);
+
     // Diff the graph
-    let results = diffGraph(
-        new EnhancedModuleGraph(baseline.graph),
-        new EnhancedModuleGraph(comparison.graph)
-    );
+    // let results = diffGraph(
+    //     new EnhancedModuleGraph(baseline.graph),
+    //     new EnhancedModuleGraph(comparison.graph)
+    // );
 
     return results;
 }

--- a/src/api/diff/diffChunkGroups.ts
+++ b/src/api/diff/diffChunkGroups.ts
@@ -1,0 +1,34 @@
+import { BundleData } from '../../types/BundleData';
+import { DiffResults } from '../../types/DiffResults';
+
+export default function diffChunkGroups(baseline: BundleData, comparison: BundleData): DiffResults {
+    const results: DiffResults = {};
+
+    // Iterate over all chunk groups
+    const allChunkGroups = new Set([
+        ...Object.keys(baseline.chunkGroups),
+        ...Object.keys(comparison.chunkGroups),
+    ]);
+
+    for (let chunkGroupName of allChunkGroups) {
+        const baselineChunkGroup = baseline.chunkGroups[chunkGroupName];
+        const comparisonChunkGroup = comparison.chunkGroups[chunkGroupName];
+
+        let delta: number;
+        if (!baselineChunkGroup) {
+            // New chunk group was added
+            delta = comparisonChunkGroup.size;
+        } else if (!comparisonChunkGroup) {
+            // Chunk group was removed
+            delta = -baselineChunkGroup.size;
+        } else {
+            // Chunk group existed before and after
+            delta = comparisonChunkGroup.size - baselineChunkGroup.size;
+        }
+
+        // Initialize the entry for the chunk group diff
+        results[chunkGroupName] = { delta, added: [], removed: [], changed: [] };
+    }
+
+    return results;
+}

--- a/src/api/diff/diffGraph.ts
+++ b/src/api/diff/diffGraph.ts
@@ -4,10 +4,9 @@ import { EnhancedModuleGraph } from './EnhancedModuleGraph';
 
 export default function diffGraph(
     baselineGraph: EnhancedModuleGraph,
-    comparisonGraph: EnhancedModuleGraph
+    comparisonGraph: EnhancedModuleGraph,
+    results: DiffResults
 ) {
-    const results: DiffResults = {};
-
     // Compare each module (the union of modules from both graphs)
     const allModules = new Set([
         ...baselineGraph.getAllModuleNames(),
@@ -17,6 +16,4 @@ export default function diffGraph(
     for (let moduleName of allModules) {
         diffModuleNode(baselineGraph, comparisonGraph, moduleName, results);
     }
-
-    return results;
 }

--- a/src/api/diff/diffModuleNode.ts
+++ b/src/api/diff/diffModuleNode.ts
@@ -19,7 +19,7 @@ export default function diffModuleNode(
 
     // Check whether this module was added, removed, or changed within each chunk group
     for (let chunkGroupName of allChunkGroups) {
-        let chunkGroupDiff = getChunkGroupDiff(results, chunkGroupName);
+        let chunkGroupDiff = results[chunkGroupName];
         if (!baselineChunkGroups.has(chunkGroupName)) {
             handleAddedModule(
                 moduleName,
@@ -47,13 +47,4 @@ export default function diffModuleNode(
 // Get the set of named chunk groups for a module, accounting for null
 function getNamedChunkGroups(module: ModuleGraphNode) {
     return new Set((module && module.namedChunkGroups) || []);
-}
-
-// Get the ChunkGroupDiff for a given chunk group, creating it if necessary
-function getChunkGroupDiff(results: DiffResults, chunkGroupName: string) {
-    if (!results[chunkGroupName]) {
-        results[chunkGroupName] = { delta: 0, added: [], removed: [], changed: [] };
-    }
-
-    return results[chunkGroupName];
 }

--- a/src/api/diff/diffModuleNode.ts
+++ b/src/api/diff/diffModuleNode.ts
@@ -52,7 +52,7 @@ function getNamedChunkGroups(module: ModuleGraphNode) {
 // Get the ChunkGroupDiff for a given chunk group, creating it if necessary
 function getChunkGroupDiff(results: DiffResults, chunkGroupName: string) {
     if (!results[chunkGroupName]) {
-        results[chunkGroupName] = { added: [], removed: [], changed: [] };
+        results[chunkGroupName] = { delta: 0, added: [], removed: [], changed: [] };
     }
 
     return results[chunkGroupName];

--- a/src/api/generateReport/generateReport.ts
+++ b/src/api/generateReport/generateReport.ts
@@ -20,7 +20,7 @@ function reportChunkGroup(chunkGroupName: string, chunkGroupDiff: ChunkGroupDiff
         return;
     }
 
-    lines.push(`## ${chunkGroupName}`);
+    lines.push(`## ${chunkGroupName} (${formatDelta(chunkGroupDiff.delta)} bytes)`);
 
     // Header
     lines.push('|| Module | Count | Size |');
@@ -28,13 +28,17 @@ function reportChunkGroup(chunkGroupName: string, chunkGroupDiff: ChunkGroupDiff
 
     for (const moduleDiff of chunkGroupDiff.added) {
         lines.push(
-            `|+|${moduleDiff.module}|${moduleDiff.weight.moduleCount}|${moduleDiff.weight.size}|`
+            `|+|${moduleDiff.module}|${moduleDiff.weight.moduleCount}|${formatDelta(
+                moduleDiff.weight.size
+            )}|`
         );
     }
 
     for (const moduleDiff of chunkGroupDiff.removed) {
         lines.push(
-            `|-|${moduleDiff.module}|${moduleDiff.weight.moduleCount}|${moduleDiff.weight.size}|`
+            `|-|${moduleDiff.module}|${moduleDiff.weight.moduleCount}|${formatDelta(
+                -moduleDiff.weight.size
+            )}|`
         );
     }
 
@@ -46,13 +50,17 @@ function reportChunkGroup(chunkGroupName: string, chunkGroupDiff: ChunkGroupDiff
             count++;
             netDelta += moduleDelta.delta;
         } else {
-            lines.push(`|△|${moduleDelta.module}| |${moduleDelta.delta}|`);
+            lines.push(`|△|${moduleDelta.module}| |${formatDelta(moduleDelta.delta)}|`);
         }
     }
 
     if (count) {
-        lines.push(`|△|*${count} modules with minor changes*| |${netDelta}|`);
+        lines.push(`|△|*${count} modules with minor changes*| |${formatDelta(netDelta)}|`);
     }
 
     lines.push('');
+}
+
+function formatDelta(delta: number) {
+    return (delta >= 0 ? '+' : '') + delta.toLocaleString();
 }

--- a/src/types/DiffResults.ts
+++ b/src/types/DiffResults.ts
@@ -5,6 +5,7 @@ export interface DiffResults {
 
 // Diff of a particular chunk group
 export interface ChunkGroupDiff {
+    delta: number;
     added: ModuleDiff[];
     removed: ModuleDiff[];
     changed: ModuleDelta[];


### PR DESCRIPTION
With this change, the diff includes the size delta of each chunk group, and it is rendered as part of the markdown report.  (Also other minor formatting improvements to the report.)