### PR TITLE
Fix delta NaN by ignoring .css assets

### DIFF
--- a/src/api/deriveBundleData/deriveChunkGroupData.ts
+++ b/src/api/deriveBundleData/deriveChunkGroupData.ts
@@ -15,8 +15,8 @@ export function deriveChunkGroupData(stats: Stats) {
 
         // Process each asset in the chunk group
         for (let asset of chunkGroup.assets) {
-            // Source maps don't count towards size
-            if (asset.endsWith('.map')) {
+            // Source maps and css don't count towards size
+            if (asset.endsWith('.map') || asset.endsWith('.css')) {
                 ignoredAssets.push(asset);
             } else {
                 assets.push(asset);

--- a/test/api/deriveChunkGroupDataTests.ts
+++ b/test/api/deriveChunkGroupDataTests.ts
@@ -58,4 +58,22 @@ describe('deriveChunkGroupData', () => {
             chunkGroup1: { size: 1, assets: ['asset1.js'], ignoredAssets: ['asset1.js.map'] },
         });
     });
+
+    it('ignores css assets', () => {
+        // Arrange
+        const stats: any = {
+            namedChunkGroups: {
+                chunkGroup1: { assets: ['asset1.js', 'asset1.css'] },
+            },
+            assets,
+        }
+
+        // Act
+        const chunkGroupData = deriveChunkGroupData(stats);
+
+        // Assert
+        expect(chunkGroupData).toEqual({
+            chunkGroup1: { size: 1, assets: ['asset1.js'], ignoredAssets: ['asset1.css'] }
+        })
+    })
 });


### PR DESCRIPTION
Hi smikula,

I ran into a problem when trying to generate a report for my project. The delta shown in the report was `null` causing report generation to fail.

I found that css assets in chunks is not in `stats.assets` array. This causes `NaN` (`undefined + number` ) when computing for chunk's total size. When passing through `JSON.stringify()` during file generation `NaN` is treated as `null`.

My proposed solution is to ignore css assets as its content does not add to the bundled js size.

I had fun reading through your code. Thank you for this awesome library.