### PR TITLE
Add option to filter out certain assets when calculating bundle data

### DIFF
--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -2,10 +2,11 @@ import { BundleData } from '../../types/BundleData';
 import { Stats } from '../../types/Stats';
 import { deriveGraph } from './deriveGraph';
 import { deriveChunkGroupData } from './deriveChunkGroupData';
+import { DataOptions } from '../../types/DataOptions';
 
-export function deriveBundleData(stats: Stats): BundleData {
+export function deriveBundleData(stats: Stats, options?: DataOptions): BundleData {
     return {
         graph: deriveGraph(stats),
-        chunkGroups: deriveChunkGroupData(stats),
+        chunkGroups: deriveChunkGroupData(stats, options),
     };
 }

--- a/src/api/deriveBundleData/deriveChunkGroupData.ts
+++ b/src/api/deriveBundleData/deriveChunkGroupData.ts
@@ -1,7 +1,9 @@
 import { Stats } from '../../types/Stats';
 import { ChunkGroupData } from '../../types/BundleData';
+import { DataOptions } from '../../types/DataOptions';
 
-export function deriveChunkGroupData(stats: Stats) {
+export function deriveChunkGroupData(stats: Stats, options: DataOptions) {
+    const assetFilter = (options && options.assetFilter) || defaultAssetFilter;
     const chunkGroupData: ChunkGroupData = {};
     const assetSizeMap = getAssetSizeMap(stats);
 
@@ -15,8 +17,7 @@ export function deriveChunkGroupData(stats: Stats) {
 
         // Process each asset in the chunk group
         for (let asset of chunkGroup.assets) {
-            // Source maps don't count towards size
-            if (asset.endsWith('.map')) {
+            if (!assetFilter(asset)) {
                 ignoredAssets.push(asset);
             } else {
                 assets.push(asset);
@@ -39,4 +40,9 @@ function getAssetSizeMap(stats: Stats) {
     }
 
     return assetSizeMap;
+}
+
+// By default filter out source maps since they don't count towards bundle size
+function defaultAssetFilter(asset: string) {
+    return !asset.endsWith('.map');
 }

--- a/src/api/diff/diff.ts
+++ b/src/api/diff/diff.ts
@@ -4,11 +4,16 @@ import { deriveBundleData } from '../deriveBundleData/deriveBundleData';
 import diffGraph from './diffGraph';
 import { EnhancedModuleGraph } from './EnhancedModuleGraph';
 import diffChunkGroups from './diffChunkGroups';
+import { DataOptions } from '../../types/DataOptions';
 
-export function diff(baseline: BundleData | Stats, comparison: BundleData | Stats) {
+export function diff(
+    baseline: BundleData | Stats,
+    comparison: BundleData | Stats,
+    options?: DataOptions
+) {
     // Derive bundle data if necessary
-    baseline = getBundleData(baseline);
-    comparison = getBundleData(comparison);
+    baseline = getBundleData(baseline, options);
+    comparison = getBundleData(comparison, options);
 
     // Diff named chunk groups
     const results = diffChunkGroups(baseline, comparison);
@@ -23,6 +28,6 @@ export function diff(baseline: BundleData | Stats, comparison: BundleData | Stat
     return results;
 }
 
-function getBundleData(data: BundleData | Stats): BundleData {
-    return (<BundleData>data).graph ? <BundleData>data : deriveBundleData(<Stats>data);
+function getBundleData(data: BundleData | Stats, options: DataOptions): BundleData {
+    return (<BundleData>data).graph ? <BundleData>data : deriveBundleData(<Stats>data, options);
 }

--- a/src/types/DataOptions.ts
+++ b/src/types/DataOptions.ts
@@ -1,0 +1,12 @@
+export interface DataOptions {
+    /**
+     * Optional filter to apply to chunk group assets.  If provided, each asset name is passed to
+     * the filter and only those for which `true` is returned are counted towards the chunk group
+     * size.
+     */
+    assetFilter?: AssetFilter;
+}
+
+export interface AssetFilter {
+    (name: string): boolean;
+}

--- a/test/api/deriveChunkGroupDataTests.ts
+++ b/test/api/deriveChunkGroupDataTests.ts
@@ -14,7 +14,7 @@ describe('deriveChunkGroupData', () => {
         };
 
         // Act
-        const chunkGroupData = deriveChunkGroupData(stats);
+        const chunkGroupData = deriveChunkGroupData(stats, null);
 
         // Assert
         expect(chunkGroupData).toEqual({
@@ -33,7 +33,7 @@ describe('deriveChunkGroupData', () => {
         };
 
         // Act
-        const chunkGroupData = deriveChunkGroupData(stats);
+        const chunkGroupData = deriveChunkGroupData(stats, null);
 
         // Assert
         expect(chunkGroupData).toEqual({
@@ -51,7 +51,7 @@ describe('deriveChunkGroupData', () => {
         };
 
         // Act
-        const chunkGroupData = deriveChunkGroupData(stats);
+        const chunkGroupData = deriveChunkGroupData(stats, null);
 
         // Assert
         expect(chunkGroupData).toEqual({

--- a/test/api/deriveChunkGroupDataTests.ts
+++ b/test/api/deriveChunkGroupDataTests.ts
@@ -41,7 +41,7 @@ describe('deriveChunkGroupData', () => {
         });
     });
 
-    it('ignores sourcemap assets', () => {
+    it('ignores sourcemap assets by default', () => {
         // Arrange
         const stats: any = {
             namedChunkGroups: {
@@ -56,6 +56,30 @@ describe('deriveChunkGroupData', () => {
         // Assert
         expect(chunkGroupData).toEqual({
             chunkGroup1: { size: 1, assets: ['asset1.js'], ignoredAssets: ['asset1.js.map'] },
+        });
+    });
+
+    it('respects the assetFilter option', () => {
+        // Arrange
+        const stats: any = {
+            namedChunkGroups: {
+                chunkGroup1: { assets: ['asset1.js', 'asset1.bad'] },
+            },
+            assets,
+        };
+
+        const assetFilter = (asset: string) => !asset.endsWith('.bad');
+
+        // Act
+        const chunkGroupData = deriveChunkGroupData(stats, { assetFilter });
+
+        // Assert
+        expect(chunkGroupData).toEqual({
+            chunkGroup1: {
+                size: 1,
+                assets: ['asset1.js'],
+                ignoredAssets: ['asset1.bad'],
+            },
         });
     });
 });


### PR DESCRIPTION
Webpack stats list all assets associated with a chunk, but some of those assets may not actually contribute to the bundle size -- possibly including source maps, CSS, or localization assets.  We ignore source maps by default, but this provides a way to ignore arbitrary assets by providing a filter function, e.g.:

```typecsript
const options = {
    assetFilter: (asset: string) => !(asset.endsWith('.map') || asset.endsWith('.css'))
}

let bundleData = deriveBundleData(stats1, stats2, options);
```