### PR TITLE
Expose the Stats types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { deriveBundleData } from './api/deriveBundleData/deriveBundleData';
 export { diff } from './api/diff/diff';
 export { generateReport } from './api/generateReport/generateReport';
+export * from './types/Stats';
 export * from './types/BundleData';
 export * from './types/DiffResults';
 export * from './types/ReportOptions';


### PR DESCRIPTION
I'm writing a small abstraction over this library in my codebase and need the Stats types exposed since using the `webpack.Stats.ToJsonOutput` has conflicts with your Stats