### PR TITLE
Correctly report parent edges in module graph

### DIFF
--- a/src/api/deriveBundleData/deriveGraph.ts
+++ b/src/api/deriveBundleData/deriveGraph.ts
@@ -72,13 +72,17 @@ export function getParents(reasons: Reason[], moduleIdToNameMap: ModuleIdToNameM
     const lazyParents = new Set<string>();
 
     for (const reason of reasons) {
-        // Skip nulls (this happens for entry point modules)
-        if (!reason.moduleId) {
+        // If moduleId is present, use that to look up the module name.  (The moduleName
+        // property, in that case, has something like "foo.js + 12 modules" which isn't what we
+        // want.)  But if there is no moduleId, use the moduleName instead - it appears to be
+        // correct in that case.
+        const moduleName =
+            (reason.moduleId && moduleIdToNameMap.get(reason.moduleId)) || reason.moduleName;
+
+        // Entry point modules will have a reason with no associated module
+        if (!moduleName) {
             continue;
         }
-
-        // We actually care about the module names
-        const moduleName = moduleIdToNameMap.get(reason.moduleId);
 
         // Distinguish between lazy and normal imports
         const isLazyParent = reason.type === 'import()';

--- a/src/api/deriveBundleData/deriveGraph.ts
+++ b/src/api/deriveBundleData/deriveGraph.ts
@@ -34,9 +34,9 @@ export function processModule(
         // This is just an individual module, so we can add it to the graph as-is
         addModuleToGraph(graph, {
             name: module.name,
-            parents: getParents(module.reasons, moduleIdToNameMap),
             namedChunkGroups,
             size: module.size,
+            ...getParents(module.reasons, moduleIdToNameMap),
         });
     } else {
         // The module is the amalgamation of multiple scope hoisted modules, so we add each of
@@ -46,10 +46,10 @@ export function processModule(
         const primaryModule = module.modules[0];
         addModuleToGraph(graph, {
             name: primaryModule.name,
-            parents: getParents(module.reasons, moduleIdToNameMap),
             containsHoistedModules: true,
             namedChunkGroups,
             size: primaryModule.size,
+            ...getParents(module.reasons, moduleIdToNameMap),
         });
 
         // Other hoisted modules are parented to the primary module
@@ -58,6 +58,8 @@ export function processModule(
             addModuleToGraph(graph, {
                 name: hoistedModule.name,
                 parents: [primaryModule.name],
+                directParents: [primaryModule.name],
+                lazyParents: [],
                 namedChunkGroups,
                 size: hoistedModule.size,
             });
@@ -66,17 +68,32 @@ export function processModule(
 }
 
 export function getParents(reasons: Reason[], moduleIdToNameMap: ModuleIdToNameMap) {
-    // Start with the module ID for each reason
-    let moduleIds = reasons.map(r => r.moduleId);
+    const directParents = new Set<string>();
+    const lazyParents = new Set<string>();
 
-    // Filter out nulls (this happens for entry point modules)
-    moduleIds = moduleIds.filter(p => p != null);
+    for (const reason of reasons) {
+        // Skip nulls (this happens for entry point modules)
+        if (!reason.moduleId) {
+            continue;
+        }
 
-    // Filter out duplicates (this happens due to scope hoisting)
-    moduleIds = [...new Set(moduleIds)];
+        // We actually care about the module names
+        const moduleName = moduleIdToNameMap.get(reason.moduleId);
 
-    // Map module IDs to module names
-    return moduleIds.map(moduleId => moduleIdToNameMap.get(moduleId));
+        // Distinguish between lazy and normal imports
+        const isLazyParent = reason.type === 'import()';
+        if (isLazyParent) {
+            lazyParents.add(moduleName);
+        } else {
+            directParents.add(moduleName);
+        }
+    }
+
+    return {
+        parents: [...directParents, ...lazyParents],
+        directParents: [...directParents],
+        lazyParents: [...lazyParents],
+    };
 }
 
 function addModuleToGraph(graph: ModuleGraph, moduleNode: ModuleGraphNode) {

--- a/src/types/BundleData.ts
+++ b/src/types/BundleData.ts
@@ -12,6 +12,8 @@ export interface ModuleGraphNode {
     containsHoistedModules?: boolean;
     name: string;
     parents: string[];
+    directParents: string[];
+    lazyParents: string[];
     size: number;
 }
 

--- a/src/types/Stats.ts
+++ b/src/types/Stats.ts
@@ -29,6 +29,7 @@ export interface Module {
 
 export interface Reason {
     moduleId: string | number;
+    moduleName: string;
     type: string;
     userRequest: string;
 }

--- a/test/api/deriveGraphTests.ts
+++ b/test/api/deriveGraphTests.ts
@@ -1,6 +1,11 @@
 import { processModule, getParents } from '../../src/api/deriveBundleData/deriveGraph';
 
-const moduleIdToNameMap: any = new Map([[1, 'module1'], [2, 'module2'], [3, 'module3']]);
+const moduleIdToNameMap: any = new Map([
+    [1, 'module1'],
+    [2, 'module2'],
+    [3, 'module3'],
+]);
+
 const namedChunkGroupLookupMap: any = { getNamedChunkGroups: () => ['chunkGroup1'] };
 
 describe('processModule', () => {
@@ -35,6 +40,8 @@ describe('processModule', () => {
         expect(graph[module.name]).toEqual({
             name: 'module1',
             parents: [],
+            directParents: [],
+            lazyParents: [],
             namedChunkGroups: ['chunkGroup1'],
             size: 123,
         });
@@ -59,6 +66,8 @@ describe('processModule', () => {
         expect(graph['module1']).toEqual({
             name: 'module1',
             parents: [],
+            directParents: [],
+            lazyParents: [],
             containsHoistedModules: true,
             namedChunkGroups: ['chunkGroup1'],
             size: 456,
@@ -74,7 +83,10 @@ describe('processModule', () => {
             reasons: [],
             chunks: [1, 2, 3],
             size: 123,
-            modules: [{ name: 'module1', size: 456 }, { name: 'module2', size: 789 }],
+            modules: [
+                { name: 'module1', size: 456 },
+                { name: 'module2', size: 789 },
+            ],
         };
 
         // Act
@@ -84,6 +96,8 @@ describe('processModule', () => {
         expect(graph['module2']).toEqual({
             name: 'module2',
             parents: ['module1'],
+            directParents: ['module1'],
+            lazyParents: [],
             namedChunkGroups: ['chunkGroup1'],
             size: 789,
         });
@@ -109,26 +123,48 @@ describe('processModule', () => {
 });
 
 describe('getParents', () => {
-    it('gets the modules from the reasons array and maps them to module names', () => {
+    it('maps module IDs to names', () => {
         // Arrange
         const reasons: any = [{ moduleId: 1 }, { moduleId: 2 }, { moduleId: 3 }];
 
         // Act
-        const parents = getParents(reasons, moduleIdToNameMap);
+        const result = getParents(reasons, moduleIdToNameMap);
 
         // Assert
-        expect(parents).toEqual(['module1', 'module2', 'module3']);
+        expect(result.parents).toEqual(['module1', 'module2', 'module3']);
     });
 
-    it('filters out nulls', () => {
+    it('prefers moduleId, if available', () => {
+        // Arrange
+        const reasons: any = [{ moduleId: 1, moduleName: 'testName' }];
+
+        // Act
+        const result = getParents(reasons, moduleIdToNameMap);
+
+        // Assert
+        expect(result.parents).toEqual(['module1']);
+    });
+
+    it('uses moduleName if moduleId is missing', () => {
+        // Arrange
+        const reasons: any = [{ moduleId: null, moduleName: 'testName' }];
+
+        // Act
+        const result = getParents(reasons, moduleIdToNameMap);
+
+        // Assert
+        expect(result.parents).toEqual(['testName']);
+    });
+
+    it('filters out entry points', () => {
         // Arrange
         const reasons: any = [{ moduleId: 1 }, { moduleId: null }, { moduleId: 3 }];
 
         // Act
-        const parents = getParents(reasons, moduleIdToNameMap);
+        const result = getParents(reasons, moduleIdToNameMap);
 
         // Assert
-        expect(parents).toEqual(['module1', 'module3']);
+        expect(result.parents).toEqual(['module1', 'module3']);
     });
 
     it('filters out duplicates', () => {
@@ -136,9 +172,38 @@ describe('getParents', () => {
         const reasons: any = [{ moduleId: 1 }, { moduleId: 1 }, { moduleId: 1 }];
 
         // Act
-        const parents = getParents(reasons, moduleIdToNameMap);
+        const result = getParents(reasons, moduleIdToNameMap);
 
         // Assert
-        expect(parents).toEqual(['module1']);
+        expect(result.parents).toEqual(['module1']);
+    });
+
+    it('distinguishes direct and lazy parents', () => {
+        // Arrange
+        const reasons: any = [
+            {
+                moduleId: 1,
+                type: 'other',
+            },
+            {
+                moduleId: 2,
+                type: 'import()',
+            },
+            {
+                moduleId: 3,
+                type: 'other',
+            },
+        ];
+
+        // Act
+        const result = getParents(reasons, moduleIdToNameMap);
+        console.log(JSON.stringify(result));
+
+        // Assert
+        expect(result).toEqual({
+            parents: ['module1', 'module3', 'module2'],
+            directParents: ['module1', 'module3'],
+            lazyParents: ['module2'],
+        });
     });
 });


### PR DESCRIPTION
This change fixes a bug where some child->parent edges were missed.  It also adds two new fields on `ModuleGraphNode`, `directParents` (corresponding to normal imports) and `lazyParents` (corresponding to dynamic imports).  These can be useful in some cases for analyzing the module graph.