### PR TITLE
Identify entrypoint modules

### DIFF
--- a/src/types/BundleData.ts
+++ b/src/types/BundleData.ts
@@ -11,6 +11,7 @@ export interface ModuleGraphNode {
     namedChunkGroups: string[];
     containsHoistedModules?: boolean;
     name: string;
+    entryType?: string;
     parents: string[];
     directParents: string[];
     lazyParents: string[];


### PR DESCRIPTION
This adds an `entryType` property to `ModuleGraphNode` which is defined for entry modules.