### PR TITLE
Optionally validate graph after creating it

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "build": "tsc",
-        "data": "yarn build && node --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json",
-        "ddata": "yarn build && node --inspect-brk --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json",
+        "data": "yarn build && node --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
+        "ddata": "yarn build && node --inspect-brk --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
         "diff": "yarn build && node lib/cli.js diff sampledata/data1.json sampledata/data2.json -o sampledata/diff.json",
         "ddiff": "yarn build && node --inspect-brk lib/cli.js diff sampledata/data1.json sampledata/data2.json -o sampledata/diff.json",
         "report": "yarn build && node lib/cli.js report sampledata/diff.json -o sampledata/report.md",

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -1,6 +1,6 @@
 import { BundleData } from '../../types/BundleData';
 import { Stats } from '../../types/Stats';
-import { deriveGraph } from './deriveGraph';
+import { deriveGraph } from './graph/deriveGraph';
 import { deriveChunkGroupData } from './deriveChunkGroupData';
 import { DataOptions } from '../../types/DataOptions';
 

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -6,7 +6,7 @@ import { DataOptions } from '../../types/DataOptions';
 
 export function deriveBundleData(stats: Stats, options?: DataOptions): BundleData {
     return {
-        graph: deriveGraph(stats),
+        graph: deriveGraph(stats, options?.validate),
         chunkGroups: deriveChunkGroupData(stats, options),
     };
 }

--- a/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
+++ b/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
@@ -1,4 +1,4 @@
-import { Stats } from '../../types/Stats';
+import { Stats } from '../../../types/Stats';
 
 // Helper class to map module IDs to module names
 export default class ModuleIdToNameMap {

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -3,8 +3,9 @@ import { Stats, Module, Reason } from '../../../types/Stats';
 import { arrayUnion } from '../../../util/arrayUnion';
 import ModuleIdToNameMap from './ModuleIdToNameMap';
 import NamedChunkGroupLookupMap from '../NamedChunkGroupLookupMap';
+import { validateGraph } from './validateGraph';
 
-export function deriveGraph(stats: Stats): ModuleGraph {
+export function deriveGraph(stats: Stats, validate?: boolean): ModuleGraph {
     const moduleIdToNameMap = new ModuleIdToNameMap(stats);
     const ncgLookup = new NamedChunkGroupLookupMap(stats);
 
@@ -12,6 +13,10 @@ export function deriveGraph(stats: Stats): ModuleGraph {
 
     for (let module of stats.modules) {
         processModule(module, graph, moduleIdToNameMap, ncgLookup);
+    }
+
+    if (validate) {
+        validateGraph(graph);
     }
 
     return graph;

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -1,8 +1,8 @@
-import { ModuleGraph, ModuleGraphNode } from '../../types/BundleData';
-import { Stats, Module, Reason } from '../../types/Stats';
-import { arrayUnion } from '../../util/arrayUnion';
+import { ModuleGraph, ModuleGraphNode } from '../../../types/BundleData';
+import { Stats, Module, Reason } from '../../../types/Stats';
+import { arrayUnion } from '../../../util/arrayUnion';
 import ModuleIdToNameMap from './ModuleIdToNameMap';
-import NamedChunkGroupLookupMap from './NamedChunkGroupLookupMap';
+import NamedChunkGroupLookupMap from '../NamedChunkGroupLookupMap';
 
 export function deriveGraph(stats: Stats): ModuleGraph {
     const moduleIdToNameMap = new ModuleIdToNameMap(stats);

--- a/src/api/deriveBundleData/graph/validateGraph.ts
+++ b/src/api/deriveBundleData/graph/validateGraph.ts
@@ -1,0 +1,39 @@
+import { ModuleGraph } from '../../../types/BundleData';
+
+export function validateGraph(graph: ModuleGraph) {
+    const errors: string[] = [];
+
+    for (const moduleName of Object.keys(graph)) {
+        // Ensure concatenated modules have been decomposed
+        if (moduleName.match(/ \+ \d+ modules$/)) {
+            errors.push('Concatenated module has not been decomposed: ' + moduleName);
+        }
+
+        // Ensure the only modules without parents are 1) entry modules or 2) the webpack runtime
+        const module = graph[moduleName];
+        if (
+            !module.directParents.length &&
+            !module.lazyParents.length &&
+            !module.entryType &&
+            !moduleName.startsWith('webpack/runtime/')
+        ) {
+            errors.push('Orphaned module: ' + moduleName);
+        }
+
+        // Validate edges
+        for (const parentName of [...module.directParents, ...module.lazyParents]) {
+            if (!graph[parentName]) {
+                errors.push(`Parent module doesn't exist: ${parentName} -> ${moduleName}`);
+            }
+        }
+    }
+
+    // If there are any errors, report them and fail
+    if (errors.length) {
+        for (const error of errors) {
+            console.error('Error: ' + error);
+        }
+
+        throw new Error('Errors detected in module graph.');
+    }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,12 +14,16 @@ program
     .command('data <stats>')
     .description('derive bundle data from stats')
     .option('-o, --outFile <string>', 'output file')
+    .option('-v, --validate', 'validate module graph')
     .action((statsPath, options) => {
         console.log('Deriving bundle data from stats...');
-        readJson(statsPath).then((stats: Stats) => {
-            const bundleData = deriveBundleData(stats);
-            fs.writeFileSync(options.outFile, JSON.stringify(bundleData, null, 2));
-        });
+        readJson(statsPath)
+            .then((stats: Stats) => {
+                const { validate } = options;
+                const bundleData = deriveBundleData(stats, { validate });
+                fs.writeFileSync(options.outFile, JSON.stringify(bundleData, null, 2));
+            })
+            .catch(reportError);
     });
 
 program
@@ -28,10 +32,12 @@ program
     .option('-o, --outFile <string>', 'output file')
     .action((baselinePath, comparisonPath, options) => {
         console.log('Diffing bundles...');
-        Promise.all([readJson(baselinePath), readJson(comparisonPath)]).then(data => {
-            let result = diff(data[0], data[1]);
-            fs.writeFileSync(options.outFile, JSON.stringify(result, null, 2));
-        });
+        Promise.all([readJson(baselinePath), readJson(comparisonPath)])
+            .then(data => {
+                let result = diff(data[0], data[1]);
+                fs.writeFileSync(options.outFile, JSON.stringify(result, null, 2));
+            })
+            .catch(reportError);
     });
 
 program
@@ -40,11 +46,17 @@ program
     .option('-o, --outFile <string>', 'output file')
     .action((diffPath, options) => {
         console.log('Generating report...');
-        readJson(diffPath).then((diff: DiffResults) => {
-            const markdown = generateReport(diff);
-            fs.writeFileSync(options.outFile, markdown);
-        });
+        readJson(diffPath)
+            .then((diff: DiffResults) => {
+                const markdown = generateReport(diff);
+                fs.writeFileSync(options.outFile, markdown);
+            })
+            .catch(reportError);
     });
 
 // Execute the command line
 program.parse(process.argv);
+
+function reportError(error: Error) {
+    console.error('webpack-bundle-diff failed with an error:', error);
+}

--- a/src/types/DataOptions.ts
+++ b/src/types/DataOptions.ts
@@ -5,6 +5,12 @@ export interface DataOptions {
      * size.
      */
     assetFilter?: AssetFilter;
+
+    /**
+     * Optional flag to validate the module graph.  If any errors are detected they are reported to
+     * the error console and the API will fail.
+     */
+    validate?: boolean;
 }
 
 export interface AssetFilter {

--- a/test/api/deriveGraphTests.ts
+++ b/test/api/deriveGraphTests.ts
@@ -1,4 +1,4 @@
-import { processModule, processReasons } from '../../src/api/deriveBundleData/deriveGraph';
+import { processModule, processReasons } from '../../src/api/deriveBundleData/graph/deriveGraph';
 
 const moduleIdToNameMap: any = new Map([
     [1, 'module1'],


### PR DESCRIPTION
This adds some optional (off by default) sanity checks when creating the module graph.  It's mostly meant to be used when developing in this package, so I haven't documented it, but it is available to consumers if they want to use it.