### PR TITLE
Support stats generated from multiple configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "build": "tsc",
-        "data": "yarn build && node --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
-        "ddata": "yarn build && node --inspect-brk --max-old-space-size=12288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
+        "data": "yarn build && node --max-old-space-size=100288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
+        "ddata": "yarn build && node --inspect-brk --max-old-space-size=100288 lib/cli.js data sampledata/stats.json -o sampledata/bundledata.json --validate",
         "diff": "yarn build && node lib/cli.js diff sampledata/data1.json sampledata/data2.json -o sampledata/diff.json",
         "ddiff": "yarn build && node --inspect-brk lib/cli.js diff sampledata/data1.json sampledata/data2.json -o sampledata/diff.json",
         "report": "yarn build && node lib/cli.js report sampledata/diff.json -o sampledata/report.md",

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -6,8 +6,6 @@ import { DataOptions } from '../../types/DataOptions';
 import { getStatsFromRawStats } from './getStatsFromRawStats';
 
 export function deriveBundleData(rawStats: RawStats, options?: DataOptions): BundleData {
-    // TODO: update readme
-    // TODO: tests
     const stats = getStatsFromRawStats(rawStats, options?.childStats);
 
     return {

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -1,10 +1,15 @@
 import { BundleData } from '../../types/BundleData';
-import { Stats } from '../../types/Stats';
+import { RawStats } from '../../types/Stats';
 import { deriveGraph } from './graph/deriveGraph';
 import { deriveChunkGroupData } from './deriveChunkGroupData';
 import { DataOptions } from '../../types/DataOptions';
+import { getStatsFromRawStats } from './getStatsFromRawStats';
 
-export function deriveBundleData(stats: Stats, options?: DataOptions): BundleData {
+export function deriveBundleData(rawStats: RawStats, options?: DataOptions): BundleData {
+    // TODO: update readme
+    // TODO: tests
+    const stats = getStatsFromRawStats(rawStats, options?.childConfig);
+
     return {
         graph: deriveGraph(stats, options?.validate),
         chunkGroups: deriveChunkGroupData(stats, options),

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -8,7 +8,7 @@ import { getStatsFromRawStats } from './getStatsFromRawStats';
 export function deriveBundleData(rawStats: RawStats, options?: DataOptions): BundleData {
     // TODO: update readme
     // TODO: tests
-    const stats = getStatsFromRawStats(rawStats, options?.childConfig);
+    const stats = getStatsFromRawStats(rawStats, options?.childStats);
 
     return {
         graph: deriveGraph(stats, options?.validate),

--- a/src/api/deriveBundleData/getStatsFromRawStats.ts
+++ b/src/api/deriveBundleData/getStatsFromRawStats.ts
@@ -1,0 +1,35 @@
+import { MultiStats, RawStats, Stats } from '../../types/Stats';
+
+export function getStatsFromRawStats(
+    rawStats: RawStats,
+    childStats: string | number | undefined
+): Stats {
+    const multiStats = rawStats as MultiStats;
+    if (multiStats.children) {
+        // Make sure we are given a childStats option
+        if (!childStats) {
+            throw new Error('Multiple configs in build; childStats must be specified.');
+        }
+
+        // First, try to look up childStats by name
+        if (typeof childStats === 'string') {
+            const stats = multiStats.children.find(s => s.name === childStats);
+            if (stats) {
+                return stats;
+            }
+        }
+
+        // Try to treat childStats as a numerical index
+        const index = typeof childStats === 'number' ? childStats : parseInt(childStats);
+        if (!isNaN(index)) {
+            const stats = multiStats.children[index];
+            if (stats) {
+                return stats;
+            }
+        }
+
+        throw new Error(`Invalid childStats value: ${childStats}`);
+    } else {
+        return rawStats as Stats;
+    }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import * as commander from 'commander';
 import * as fs from 'fs';
 import readJson from './util/readJson';
-import { Stats } from './types/Stats';
+import { RawStats } from './types/Stats';
 import { deriveBundleData, diff, generateReport, DiffResults } from './index';
 
 // Read the package version from package.json
@@ -14,13 +14,14 @@ program
     .command('data <stats>')
     .description('derive bundle data from stats')
     .option('-o, --outFile <string>', 'output file')
+    .option('-c, --childStats <string>', 'child stats name or index')
     .option('-v, --validate', 'validate module graph')
     .action((statsPath, options) => {
         console.log('Deriving bundle data from stats...');
         readJson(statsPath)
-            .then((stats: Stats) => {
-                const { validate } = options;
-                const bundleData = deriveBundleData(stats, { validate });
+            .then((stats: RawStats) => {
+                const { childStats, validate } = options;
+                const bundleData = deriveBundleData(stats, { childStats, validate });
                 fs.writeFileSync(options.outFile, JSON.stringify(bundleData, null, 2));
             })
             .catch(reportError);

--- a/src/types/DataOptions.ts
+++ b/src/types/DataOptions.ts
@@ -11,6 +11,12 @@ export interface DataOptions {
      * the error console and the API will fail.
      */
     validate?: boolean;
+
+    /**
+     * Optional specifier for the child stats to use, if the webpack build included multiple
+     * configs.  This can be the stats name or an index into the children array.
+     */
+    childStats?: string | number;
 }
 
 export interface AssetFilter {

--- a/src/types/Stats.ts
+++ b/src/types/Stats.ts
@@ -4,7 +4,14 @@ export interface Stats {
     chunks: Chunk[];
     modules: Module[];
     namedChunkGroups: { [name: string]: NamedChunkGroup };
+    name?: string;
 }
+
+export interface MultiStats {
+    children: Stats[];
+}
+
+export type RawStats = Stats | MultiStats;
 
 export interface Asset {
     name: string;

--- a/test/api/getStatsFromRawStatsTests.ts
+++ b/test/api/getStatsFromRawStatsTests.ts
@@ -1,0 +1,6 @@
+describe('getStatsFromRawStats', () => {
+    const stats1 = { name: 'stats1' };
+    const stats2 = { name: 'stats2' };
+
+    it('for just a single stats, returns it', () => {});
+});

--- a/test/api/getStatsFromRawStatsTests.ts
+++ b/test/api/getStatsFromRawStatsTests.ts
@@ -1,6 +1,61 @@
-describe('getStatsFromRawStats', () => {
-    const stats1 = { name: 'stats1' };
-    const stats2 = { name: 'stats2' };
+import { getStatsFromRawStats } from '../../src/api/deriveBundleData/getStatsFromRawStats';
+import { MultiStats, Stats } from '../../src/types/Stats';
 
-    it('for just a single stats, returns it', () => {});
+describe('getStatsFromRawStats', () => {
+    const stats1 = { name: 'stats1' } as Stats;
+    const stats2 = { name: 'stats2' } as Stats;
+    const multiStats = { children: [stats1, stats2] } as MultiStats;
+
+    it('if passed a single stats object, just returns it', () => {
+        // Act
+        const result = getStatsFromRawStats(stats1, undefined);
+
+        // Assert
+        expect(result).toBe(stats1);
+    });
+
+    it('throws if multiple stats and childStats not specified', () => {
+        // Act / Assert
+        expect(() => {
+            getStatsFromRawStats(multiStats, undefined);
+        }).toThrow();
+    });
+
+    it('returns child stats by name', () => {
+        // Act
+        const result = getStatsFromRawStats(multiStats, 'stats2');
+
+        // Assert
+        expect(result).toBe(stats2);
+    });
+
+    it('throws if unable to find child stats by name', () => {
+        // Act / Assert
+        expect(() => {
+            getStatsFromRawStats(multiStats, 'invalidName');
+        }).toThrow();
+    });
+
+    it('returns child stats by numerical index', () => {
+        // Act
+        const result = getStatsFromRawStats(multiStats, 1);
+
+        // Assert
+        expect(result).toBe(stats2);
+    });
+
+    it('returns child stats by string index', () => {
+        // Act
+        const result = getStatsFromRawStats(multiStats, '1');
+
+        // Assert
+        expect(result).toBe(stats2);
+    });
+
+    it('throws if unable to find child stats by index', () => {
+        // Act / Assert
+        expect(() => {
+            getStatsFromRawStats(multiStats, 2);
+        }).toThrow();
+    });
 });


### PR DESCRIPTION
It is possible to run webpack with [multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations) at once, in which case the stats object will have a `children` array with the stats for each build.  This change adds an optional `childStats` option to choose which stats to generate the bundle stats from, either by specifying the config name or an index into the `children` array.

E.g. `wbd data stats.json -o bundlestats.json --childStats commonjs`