### PR TITLE
Support generating stats using Compilation object

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
         "ts-jest": "^28.0.3",
-        "typescript": "~4.7.2"
+        "typescript": "~4.7.2",
+        "webpack": "^5.74.0"
     },
     "repository": {
         "type": "git",

--- a/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
+++ b/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
@@ -12,7 +12,7 @@ export default class NamedChunkGroupLookupMap {
             ? stats.namedChunkGroups
             : Object.entries(stats.namedChunkGroups)) {
             for (let chunk of chunkGroup.chunks) {
-                const chunkId = chunk instanceof Chunk ? chunk.id : chunk;
+                const chunkId = typeof chunk === 'object' ? chunk.id : chunk;
                 if (!this.map.has(chunkId)) {
                     this.map.set(chunkId, []);
                 }

--- a/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
+++ b/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
@@ -1,16 +1,18 @@
+import { Chunk, Compilation } from 'webpack';
 import { Stats, ChunkId } from '../../types/Stats';
 
 // Helper class to look up what named chunk groups a given chunk is in
 export default class NamedChunkGroupLookupMap {
     private map: Map<ChunkId, string[]>;
 
-    constructor(stats: Stats) {
+    constructor(stats: Stats | Compilation) {
         // Initialize the map from the given stats
         this.map = new Map();
-        for (let name of Object.keys(stats.namedChunkGroups)) {
-            const chunkGroup = stats.namedChunkGroups[name];
-
-            for (let chunkId of chunkGroup.chunks) {
+        for (let [name, chunkGroup] of stats.namedChunkGroups instanceof Map
+            ? stats.namedChunkGroups
+            : Object.entries(stats.namedChunkGroups)) {
+            for (let chunk of chunkGroup.chunks) {
+                const chunkId = chunk instanceof Chunk ? chunk.id : chunk;
                 if (!this.map.has(chunkId)) {
                     this.map.set(chunkId, []);
                 }

--- a/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
+++ b/src/api/deriveBundleData/NamedChunkGroupLookupMap.ts
@@ -1,4 +1,4 @@
-import { Chunk, Compilation } from 'webpack';
+import { Compilation } from 'webpack';
 import { Stats, ChunkId } from '../../types/Stats';
 
 // Helper class to look up what named chunk groups a given chunk is in

--- a/src/api/deriveBundleData/deriveBundleData.ts
+++ b/src/api/deriveBundleData/deriveBundleData.ts
@@ -4,8 +4,12 @@ import { deriveGraph } from './graph/deriveGraph';
 import { deriveChunkGroupData } from './deriveChunkGroupData';
 import { DataOptions } from '../../types/DataOptions';
 import { getStatsFromRawStats } from './getStatsFromRawStats';
+import { MultiStats, Stats } from 'webpack';
 
-export function deriveBundleData(rawStats: RawStats, options?: DataOptions): BundleData {
+export function deriveBundleData(
+    rawStats: RawStats | Stats | MultiStats,
+    options?: DataOptions
+): BundleData {
     const stats = getStatsFromRawStats(rawStats, options?.childStats);
 
     return {

--- a/src/api/deriveBundleData/deriveChunkGroupData.ts
+++ b/src/api/deriveBundleData/deriveChunkGroupData.ts
@@ -2,13 +2,14 @@ import { Stats } from '../../types/Stats';
 import { ChunkGroupData } from '../../types/BundleData';
 import { DataOptions } from '../../types/DataOptions';
 import { Compilation } from 'webpack';
+import { isChunkGroup, isCompilation } from '../../util/typeGuards';
 
 export function deriveChunkGroupData(stats: Stats | Compilation, options: DataOptions) {
     const assetFilter = (options && options.assetFilter) || defaultAssetFilter;
     const chunkGroupData: ChunkGroupData = {};
 
     // Process each named chunk group
-    for (let chunkGroupName of stats.namedChunkGroups instanceof Map
+    for (let chunkGroupName of isCompilation(stats)
         ? stats.namedChunkGroups.keys()
         : Object.keys(stats.namedChunkGroups)) {
         const chunkGroup =
@@ -20,13 +21,12 @@ export function deriveChunkGroupData(stats: Stats | Compilation, options: DataOp
         let assets: string[] = [];
         let ignoredAssets: string[] = [];
 
-        const chunkGroupAssets =
-            'pushChunk' in chunkGroup
-                ? chunkGroup.getFiles().map((assetName: string) => ({
-                      name: assetName,
-                      size: (stats as Compilation).getAsset(assetName).info.size,
-                  }))
-                : chunkGroup.assets;
+        const chunkGroupAssets = isChunkGroup(chunkGroup)
+            ? chunkGroup.getFiles().map((assetName: string) => ({
+                  name: assetName,
+                  size: (stats as Compilation).getAsset(assetName).info.size,
+              }))
+            : chunkGroup.assets;
 
         // Process each asset in the chunk group
         for (let { name, size } of chunkGroupAssets) {

--- a/src/api/deriveBundleData/deriveChunkGroupData.ts
+++ b/src/api/deriveBundleData/deriveChunkGroupData.ts
@@ -8,7 +8,9 @@ export function deriveChunkGroupData(stats: Stats | Compilation, options: DataOp
     const chunkGroupData: ChunkGroupData = {};
 
     // Process each named chunk group
-    for (let chunkGroupName of Object.keys(stats.namedChunkGroups)) {
+    for (let chunkGroupName of stats.namedChunkGroups instanceof Map
+        ? stats.namedChunkGroups.keys()
+        : Object.keys(stats.namedChunkGroups)) {
         const chunkGroup =
             stats.namedChunkGroups instanceof Map
                 ? stats.namedChunkGroups.get(chunkGroupName)
@@ -20,12 +22,10 @@ export function deriveChunkGroupData(stats: Stats | Compilation, options: DataOp
 
         const chunkGroupAssets =
             'pushChunk' in chunkGroup
-                ? chunkGroup
-                      .getFiles()
-                      .map((assetName: string) => ({
-                          name: assetName,
-                          size: (stats as Compilation).getAsset(assetName).info.size,
-                      }))
+                ? chunkGroup.getFiles().map((assetName: string) => ({
+                      name: assetName,
+                      size: (stats as Compilation).getAsset(assetName).info.size,
+                  }))
                 : chunkGroup.assets;
 
         // Process each asset in the chunk group

--- a/src/api/deriveBundleData/getStatsFromRawStats.ts
+++ b/src/api/deriveBundleData/getStatsFromRawStats.ts
@@ -1,11 +1,12 @@
 import { Stats as SingleCompilationStats } from '../../types/Stats';
 import { Compilation, MultiStats, Stats, StatsCompilation } from 'webpack';
+import { isMultiStats, isStats, isStatsCompilation } from '../../util/typeGuards';
 
 export function getStatsFromRawStats(
     rawStats: StatsCompilation | Stats | MultiStats,
     childStats: string | number | undefined
 ): SingleCompilationStats | Compilation {
-    if ('children' in rawStats || 'stats' in rawStats) {
+    if (isStatsCompilation(rawStats) || isMultiStats(rawStats)) {
         // Make sure we are given a childStats option
         if (!childStats) {
             throw new Error('Multiple configs in build; childStats must be specified.');
@@ -13,31 +14,29 @@ export function getStatsFromRawStats(
 
         // First, try to look up childStats by name
         if (typeof childStats === 'string') {
-            const stats =
-                'children' in rawStats
-                    ? rawStats.children.find(s => s.name === childStats)
-                    : (rawStats as MultiStats).stats.find(
-                          ({ compilation: { name } }) => name === childStats
-                      );
+            const stats = isStatsCompilation(rawStats)
+                ? rawStats.children.find(s => s.name === childStats)
+                : (rawStats as MultiStats).stats.find(
+                      ({ compilation: { name } }) => name === childStats
+                  );
             if (stats) {
-                return 'compilation' in stats ? stats.compilation : stats;
+                return isStats(stats) ? stats.compilation : (stats as SingleCompilationStats);
             }
         }
 
         // Try to treat childStats as a numerical index
         const index = typeof childStats === 'number' ? childStats : parseInt(childStats);
         if (!isNaN(index)) {
-            const stats =
-                'children' in rawStats
-                    ? rawStats.children[index]
-                    : rawStats.stats[index].compilation;
+            const stats = isStatsCompilation(rawStats)
+                ? rawStats.children[index]
+                : rawStats.stats[index].compilation;
             if (stats) {
-                return 'compilation' in stats ? stats.compilation : stats;
+                return isStats(stats) ? stats.compilation : (stats as SingleCompilationStats);
             }
         }
 
         throw new Error(`Invalid childStats value: ${childStats}`);
-    } else if ('compilation' in rawStats) {
+    } else if (isStats(rawStats)) {
         return rawStats.compilation;
     } else {
         return rawStats as SingleCompilationStats;

--- a/src/api/deriveBundleData/getStatsFromRawStats.ts
+++ b/src/api/deriveBundleData/getStatsFromRawStats.ts
@@ -1,11 +1,11 @@
-import { MultiStats, RawStats, Stats } from '../../types/Stats';
+import { Stats as SingleCompilationStats } from '../../types/Stats';
+import { Compilation, MultiStats, Stats, StatsCompilation } from 'webpack';
 
 export function getStatsFromRawStats(
-    rawStats: RawStats,
+    rawStats: StatsCompilation | Stats | MultiStats,
     childStats: string | number | undefined
-): Stats {
-    const multiStats = rawStats as MultiStats;
-    if (multiStats.children) {
+): SingleCompilationStats | Compilation {
+    if ('children' in rawStats || rawStats instanceof MultiStats) {
         // Make sure we are given a childStats option
         if (!childStats) {
             throw new Error('Multiple configs in build; childStats must be specified.');
@@ -13,23 +13,35 @@ export function getStatsFromRawStats(
 
         // First, try to look up childStats by name
         if (typeof childStats === 'string') {
-            const stats = multiStats.children.find(s => s.name === childStats);
+            const stats =
+                rawStats instanceof MultiStats
+                    ? rawStats.stats.find(({ compilation: { name } }) => name === childStats)
+                    : rawStats.children.find(s => s.name === childStats);
             if (stats) {
-                return stats;
+                return stats instanceof Stats
+                    ? stats.compilation
+                    : (stats as SingleCompilationStats);
             }
         }
 
         // Try to treat childStats as a numerical index
         const index = typeof childStats === 'number' ? childStats : parseInt(childStats);
         if (!isNaN(index)) {
-            const stats = multiStats.children[index];
+            const stats =
+                rawStats instanceof MultiStats
+                    ? rawStats.stats[index].compilation
+                    : rawStats.children[index];
             if (stats) {
-                return stats;
+                return stats instanceof Stats
+                    ? stats.compilation
+                    : (stats as SingleCompilationStats);
             }
         }
 
         throw new Error(`Invalid childStats value: ${childStats}`);
+    } else if (rawStats instanceof Stats) {
+        return rawStats.compilation;
     } else {
-        return rawStats as Stats;
+        return rawStats as SingleCompilationStats;
     }
 }

--- a/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
+++ b/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
@@ -1,15 +1,26 @@
-import { Stats } from '../../../types/Stats';
+import { Compilation, Module } from 'webpack';
+import { Stats, Module as StatsModule } from '../../../types/Stats';
 
 // Helper class to map module IDs to module names
 export default class ModuleIdToNameMap {
     private map: Map<string | number, string>;
 
-    constructor(stats: Stats) {
+    constructor(stats: Stats | Compilation) {
         // Initialize the map from the given stats
         this.map = new Map();
-        for (let module of stats.modules) {
+        for (let module of stats.modules as Iterable<
+            | StatsModule
+            | (Module & {
+                  readableIdentifier(requestShortener: Compilation['requestShortener']): string;
+              })
+        >) {
             // If the module contains multiple hoisted modules, assume the first one is the primary module
-            let name = module.modules ? module.modules[0].name : module.name;
+            let name =
+                'readableIdentifier' in module
+                    ? module.readableIdentifier((stats as Compilation).requestShortener)
+                    : module.modules
+                    ? module.modules[0].name
+                    : module.name;
             this.map.set(module.id, name);
         }
     }

--- a/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
+++ b/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
@@ -1,5 +1,6 @@
 import { Compilation, Module } from 'webpack';
 import { Stats, Module as StatsModule } from '../../../types/Stats';
+import { getModuleName } from '../../../util/getModuleName';
 
 // Helper class to map module IDs to module names
 export default class ModuleIdToNameMap {
@@ -15,12 +16,7 @@ export default class ModuleIdToNameMap {
               })
         >) {
             // If the module contains multiple hoisted modules, assume the first one is the primary module
-            let name =
-                'readableIdentifier' in module
-                    ? module.readableIdentifier((stats as Compilation).requestShortener)
-                    : module.modules
-                    ? module.modules[0].name
-                    : module.name;
+            let name = getModuleName(module, stats);
             this.map.set(module.id, name);
         }
     }

--- a/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
+++ b/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
@@ -1,6 +1,7 @@
 import { Compilation, Module } from 'webpack';
 import { Stats, Module as StatsModule } from '../../../types/Stats';
 import { getModuleName } from '../../../util/getModuleName';
+import { getId } from '../../../util/getId';
 
 // Helper class to map module IDs to module names
 export default class ModuleIdToNameMap {
@@ -16,8 +17,8 @@ export default class ModuleIdToNameMap {
               })
         >) {
             // If the module contains multiple hoisted modules, assume the first one is the primary module
-            let name = getModuleName(module, stats);
-            this.map.set(module.id, name);
+            const name = getModuleName(module, stats);
+            this.map.set(getId(module, stats), name);
         }
     }
 

--- a/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
+++ b/src/api/deriveBundleData/graph/ModuleIdToNameMap.ts
@@ -1,7 +1,8 @@
-import { Compilation, Module } from 'webpack';
-import { Stats, Module as StatsModule } from '../../../types/Stats';
+import { Compilation } from 'webpack';
+import { Stats } from '../../../types/Stats';
 import { getModuleName } from '../../../util/getModuleName';
 import { getId } from '../../../util/getId';
+import { StatsOrComiplationModule } from '../../../types/StatsOrComiplationModule';
 
 // Helper class to map module IDs to module names
 export default class ModuleIdToNameMap {
@@ -10,12 +11,8 @@ export default class ModuleIdToNameMap {
     constructor(stats: Stats | Compilation) {
         // Initialize the map from the given stats
         this.map = new Map();
-        for (let module of stats.modules as Iterable<
-            | StatsModule
-            | (Module & {
-                  readableIdentifier(requestShortener: Compilation['requestShortener']): string;
-              })
-        >) {
+
+        for (let module of stats.modules as Iterable<StatsOrComiplationModule>) {
             // If the module contains multiple hoisted modules, assume the first one is the primary module
             const name = getModuleName(module, stats);
             this.map.set(getId(module, stats), name);

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -79,7 +79,7 @@ export function processModule(
 
         // Assume the first hoisted module acts as the primary module
         addModuleToGraph(graph, {
-            name: moduleName,
+            name: getModuleName(module.modules[0], compilation),
             containsHoistedModules: true,
             namedChunkGroups,
             size: moduleSize,

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -42,8 +42,8 @@ export function processModule(
     const moduleName = moduleIdToNameMap.get(module.id);
     const moduleSize = typeof module.size === 'number' ? module.size : module.size();
     const moduleReasons =
-        module instanceof Module
-            ? [...(compilation as Compilation).moduleGraph.getIncomingConnections(module)]
+        'hasReasons' in module
+            ? [...(compilation as Compilation).moduleGraph.getIncomingConnections(module as Module)]
                   .map(
                       ({ dependency }) =>
                           dependency && compilation.moduleGraph.getModule(dependency).identifier()
@@ -53,7 +53,7 @@ export function processModule(
 
     // Precalculate named chunk groups since they are the same for all submodules
     const moduleChunks: (string | number | null)[] =
-        module instanceof Module ? module.getChunks().map(({ id }) => id) : module.chunks;
+        'hasReasons' in module ? (module as Module).getChunks().map(({ id }) => id) : module.chunks;
     const namedChunkGroups = ncgLookup.getNamedChunkGroups(moduleChunks);
 
     if (!module.modules) {

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -53,7 +53,11 @@ export function processModule(
 
     // Precalculate named chunk groups since they are the same for all submodules
     const moduleChunks: (string | number | null)[] =
-        'hasReasons' in module ? (module as Module).getChunks().map(({ id }) => id) : module.chunks;
+        'hasReasons' in module
+            ? (compilation as Compilation).chunkGraph
+                  .getModuleChunks(module as Module)
+                  .map(chunk => chunk.id)
+            : module.chunks;
     const namedChunkGroups = ncgLookup.getNamedChunkGroups(moduleChunks);
 
     if (!module.modules) {

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -1,19 +1,20 @@
 import { ModuleGraph, ModuleGraphNode } from '../../../types/BundleData';
-import { Stats, Module } from '../../../types/Stats';
+import { Stats } from '../../../types/Stats';
 import { arrayUnion } from '../../../util/arrayUnion';
 import ModuleIdToNameMap from './ModuleIdToNameMap';
 import NamedChunkGroupLookupMap from '../NamedChunkGroupLookupMap';
 import { validateGraph } from './validateGraph';
 import { processReasons } from './processReasons';
+import { Compilation, StatsModule, Module } from 'webpack';
 
-export function deriveGraph(stats: Stats, validate?: boolean): ModuleGraph {
+export function deriveGraph(stats: Stats | Compilation, validate?: boolean): ModuleGraph {
     const moduleIdToNameMap = new ModuleIdToNameMap(stats);
     const ncgLookup = new NamedChunkGroupLookupMap(stats);
 
     let graph: ModuleGraph = {};
 
     for (let module of stats.modules) {
-        processModule(module, graph, moduleIdToNameMap, ncgLookup);
+        processModule(module, graph, moduleIdToNameMap, ncgLookup, stats);
     }
 
     if (validate) {
@@ -24,51 +25,71 @@ export function deriveGraph(stats: Stats, validate?: boolean): ModuleGraph {
 }
 
 export function processModule(
-    module: Module,
+    uncastModule: Module | StatsModule,
     graph: ModuleGraph,
     moduleIdToNameMap: ModuleIdToNameMap,
-    ncgLookup: NamedChunkGroupLookupMap
-) {
+    ncgLookup: NamedChunkGroupLookupMap,
+    compilation: Compilation | Stats
+): void {
+    const module = uncastModule as StatsModule | (Module & { modules?: Module[] });
+    const moduleIdentifier =
+        typeof module.identifier === 'string' ? module.identifier : module.identifier?.();
     // Modules marked as ignored don't get bundled, so we can ignore them too
-    if (module.identifier.startsWith('ignored ')) {
+    if (moduleIdentifier?.startsWith('ignored ')) {
         return;
     }
 
+    const moduleName = moduleIdToNameMap.get(module.id);
+    const moduleSize = typeof module.size === 'number' ? module.size : module.size();
+    const moduleReasons =
+        module instanceof Module
+            ? [...(compilation as Compilation).moduleGraph.getIncomingConnections(module)]
+                  .map(
+                      ({ dependency }) =>
+                          dependency && compilation.moduleGraph.getModule(dependency).identifier()
+                  )
+                  .filter(reason => !!reason)
+            : module.reasons;
+
     // Precalculate named chunk groups since they are the same for all submodules
-    const namedChunkGroups = ncgLookup.getNamedChunkGroups(module.chunks);
+    const moduleChunks: (string | number | null)[] =
+        module instanceof Module ? module.getChunks().map(({ id }) => id) : module.chunks;
+    const namedChunkGroups = ncgLookup.getNamedChunkGroups(moduleChunks);
 
     if (!module.modules) {
         // This is just an individual module, so we can add it to the graph as-is
         addModuleToGraph(graph, {
-            name: module.name,
+            name: moduleName,
             namedChunkGroups,
-            size: module.size,
-            ...processReasons(module.reasons, moduleIdToNameMap),
+            size: moduleSize,
+            ...processReasons(moduleReasons, moduleIdToNameMap),
         });
     } else {
         // The module is the amalgamation of multiple scope hoisted modules, so we add each of
         // them individually.
 
         // Assume the first hoisted module acts as the primary module
-        const primaryModule = module.modules[0];
         addModuleToGraph(graph, {
-            name: primaryModule.name,
+            name: moduleName,
             containsHoistedModules: true,
             namedChunkGroups,
-            size: primaryModule.size,
-            ...processReasons(module.reasons, moduleIdToNameMap),
+            size: moduleSize,
+            ...processReasons(moduleReasons, moduleIdToNameMap),
         });
 
         // Other hoisted modules are parented to the primary module
         for (let i = 1; i < module.modules.length; i++) {
             const hoistedModule = module.modules[i];
+            const hoistedModuleName = moduleIdToNameMap.get(hoistedModule.id);
+            const hoistedModuleSize =
+                typeof hoistedModule.size === 'number' ? hoistedModule.size : hoistedModule.size();
             addModuleToGraph(graph, {
-                name: hoistedModule.name,
-                parents: [primaryModule.name],
-                directParents: [primaryModule.name],
+                name: hoistedModuleName,
+                parents: [moduleName],
+                directParents: [moduleName],
                 lazyParents: [],
                 namedChunkGroups,
-                size: hoistedModule.size,
+                size: hoistedModuleSize,
             });
         }
     }

--- a/src/api/deriveBundleData/graph/processReasons.ts
+++ b/src/api/deriveBundleData/graph/processReasons.ts
@@ -43,6 +43,6 @@ export function processReasons(reasons: Reason[], moduleIdToNameMap: ModuleIdToN
         parents: [...directParents, ...lazyParents],
         directParents: [...directParents],
         lazyParents: [...lazyParents],
-        ...(entryType ? { entryType } : {}),
+        entryType,
     };
 }

--- a/src/api/deriveBundleData/graph/processReasons.ts
+++ b/src/api/deriveBundleData/graph/processReasons.ts
@@ -43,6 +43,6 @@ export function processReasons(reasons: Reason[], moduleIdToNameMap: ModuleIdToN
         parents: [...directParents, ...lazyParents],
         directParents: [...directParents],
         lazyParents: [...lazyParents],
-        entryType,
+        ...(entryType ? { entryType } : {}),
     };
 }

--- a/src/types/Stats.ts
+++ b/src/types/Stats.ts
@@ -9,7 +9,7 @@ import {
 
 // A minimal subset of the stats.json schema
 export type Stats = StatsCompilation &
-    Required<Pick<StatsCompilation, 'assets' | 'chunks' | 'modules' | 'namedChunkGroups' | 'name'>>;
+    Required<Pick<StatsCompilation, 'assets' | 'chunks' | 'modules' | 'namedChunkGroups'>>;
 
 export type MultiStats = StatsCompilation & Required<Pick<StatsCompilation, 'children'>>;
 

--- a/src/types/Stats.ts
+++ b/src/types/Stats.ts
@@ -1,51 +1,30 @@
+import {
+    StatsAsset,
+    StatsChunk,
+    StatsChunkGroup,
+    StatsCompilation,
+    StatsModule,
+    StatsModuleReason,
+} from 'webpack';
+
 // A minimal subset of the stats.json schema
-export interface Stats {
-    assets: Asset[];
-    chunks: Chunk[];
-    modules: Module[];
-    namedChunkGroups: { [name: string]: NamedChunkGroup };
-    name?: string;
-}
+export type Stats = StatsCompilation &
+    Required<Pick<StatsCompilation, 'assets' | 'chunks' | 'modules' | 'namedChunkGroups' | 'name'>>;
 
-export interface MultiStats {
-    children: Stats[];
-}
+export type MultiStats = StatsCompilation & Required<Pick<StatsCompilation, 'children'>>;
 
-export type RawStats = Stats | MultiStats;
+export type RawStats = StatsCompilation;
 
-export interface Asset {
-    name: string;
-    chunks: ChunkId[];
-    size: number;
-}
+export type Asset = StatsAsset;
 
-export interface Chunk {
-    id: ChunkId;
-    modules: Module[];
-}
+export type Chunk = StatsChunk;
 
-export interface Module {
-    chunks: ChunkId[];
-    id: string | number;
-    identifier: string;
-    modules?: Module[];
-    name: string;
-    reasons: Reason[];
-    size: number;
-}
+export type Module = StatsModule;
 
-export interface Reason {
-    moduleId: string | number;
-    moduleName: string;
-    type: string;
-    userRequest: string;
-}
+export type Reason = StatsModuleReason;
 
 export type ChunkAsset = Pick<Asset, 'name' | 'size'>;
 
-export interface NamedChunkGroup {
-    assets: ChunkAsset[];
-    chunks: ChunkId[];
-}
+export type NamedChunkGroup = StatsChunkGroup;
 
 export type ChunkId = number | string;

--- a/src/types/StatsOrComiplationModule.ts
+++ b/src/types/StatsOrComiplationModule.ts
@@ -1,0 +1,8 @@
+import { Compilation, Module } from 'webpack';
+import { Module as StatsModule } from './Stats';
+
+export type StatsOrComiplationModule =
+    | StatsModule
+    | (Module & {
+          readableIdentifier(requestShortener: Compilation['requestShortener']): string;
+      });

--- a/src/util/getId.ts
+++ b/src/util/getId.ts
@@ -1,0 +1,10 @@
+import { Compilation, Module } from 'webpack';
+import { Stats, Module as StatsModule } from '../types/Stats';
+
+export function getId(m: Module | StatsModule, stats: Stats | Compilation) {
+    if ('hooks' in stats) {
+        (stats as Compilation).chunkGraph.getModuleId(m as Module);
+    } else {
+        return m.id;
+    }
+}

--- a/src/util/getModuleName.ts
+++ b/src/util/getModuleName.ts
@@ -1,0 +1,17 @@
+import { Compilation, Module } from 'webpack';
+import { Stats, Module as StatsModule } from '../types/Stats';
+
+export function getModuleName(
+    module:
+        | StatsModule
+        | (Module & {
+              readableIdentifier(requestShortener: Compilation['requestShortener']): string;
+          }),
+    stats: Stats | Compilation
+): string {
+    return 'readableIdentifier' in module
+        ? module.readableIdentifier((stats as Compilation).requestShortener)
+        : module.modules
+        ? module.modules[0].name
+        : module.name;
+}

--- a/src/util/getModuleName.ts
+++ b/src/util/getModuleName.ts
@@ -1,12 +1,9 @@
-import { Compilation, Module } from 'webpack';
-import { Stats, Module as StatsModule } from '../types/Stats';
+import { Compilation } from 'webpack';
+import { Stats } from '../types/Stats';
+import { StatsOrComiplationModule } from '../types/StatsOrComiplationModule';
 
 export function getModuleName(
-    module:
-        | StatsModule
-        | (Module & {
-              readableIdentifier(requestShortener: Compilation['requestShortener']): string;
-          }),
+    module: StatsOrComiplationModule,
     stats: Stats | Compilation
 ): string {
     return 'readableIdentifier' in module

--- a/src/util/isCompilation.ts
+++ b/src/util/isCompilation.ts
@@ -1,0 +1,5 @@
+import { Compilation } from 'webpack';
+
+export function isCompilation(rawStats: object): rawStats is Compilation {
+    return 'hooks' in rawStats;
+}

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -1,0 +1,40 @@
+import {
+    Compilation,
+    Module,
+    MultiStats,
+    Stats,
+    StatsChunkGroup,
+    StatsCompilation,
+    StatsModule,
+} from 'webpack';
+
+export function isStatsCompilation(
+    stats: StatsCompilation | Stats | MultiStats
+): stats is StatsCompilation {
+    return 'children' in stats;
+}
+
+export function isMultiStats(stats: StatsCompilation | Stats | MultiStats): stats is MultiStats {
+    return 'stats' in stats;
+}
+
+export function isStats(
+    stats: StatsCompilation | Stats | MultiStats | Compilation
+): stats is Stats {
+    return 'compilation' in stats;
+}
+
+// ChunkGroup is not directly exported from webpack types
+export type ChunkGroup = Compilation['chunkGroups'] extends (infer T)[] ? T : never;
+
+export function isChunkGroup(chunkGroup: StatsChunkGroup | ChunkGroup): chunkGroup is ChunkGroup {
+    return 'pushChunk' in chunkGroup;
+}
+
+export function isCompilation(stats: Compilation | StatsCompilation): stats is Compilation {
+    return 'hooks' in stats;
+}
+
+export function isStatsModule(mod: StatsModule | Module): mod is StatsModule {
+    return typeof mod.identifier === 'string';
+}

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -35,6 +35,6 @@ export function isCompilation(stats: Compilation | StatsCompilation): stats is C
     return 'hooks' in stats;
 }
 
-export function isStatsModule(mod: StatsModule | Module): mod is StatsModule {
-    return typeof mod.identifier === 'string';
+export function isModule(mod: StatsModule | Module): mod is Module {
+    return 'addChunk' in mod;
 }

--- a/test/api/deriveGraphTests.ts
+++ b/test/api/deriveGraphTests.ts
@@ -1,10 +1,13 @@
 import { processModule } from '../../src/api/deriveBundleData/graph/deriveGraph';
+import { Stats } from '../../src/types/Stats';
 
 const moduleIdToNameMap: any = new Map([
     [1, 'module1'],
     [2, 'module2'],
     [3, 'module3'],
 ]);
+
+const stats: Stats = {} as Stats;
 
 const namedChunkGroupLookupMap: any = { getNamedChunkGroups: () => ['chunkGroup1'] };
 
@@ -15,7 +18,7 @@ describe('processModule', () => {
         const module: any = { identifier: 'ignored module1' };
 
         // Act
-        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap);
+        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap, stats);
 
         // Assert
         expect(graph).toEqual({});
@@ -34,7 +37,7 @@ describe('processModule', () => {
         };
 
         // Act
-        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap);
+        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap, stats);
 
         // Assert
         expect(graph[module.name]).toEqual({
@@ -60,7 +63,7 @@ describe('processModule', () => {
         };
 
         // Act
-        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap);
+        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap, stats);
 
         // Assert
         expect(graph['module1']).toEqual({
@@ -90,7 +93,7 @@ describe('processModule', () => {
         };
 
         // Act
-        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap);
+        processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap, stats);
 
         // Assert
         expect(graph['module2']).toEqual({
@@ -117,7 +120,7 @@ describe('processModule', () => {
 
         // Act / Assert
         expect(() => {
-            processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap);
+            processModule(module, graph, moduleIdToNameMap, namedChunkGroupLookupMap, stats);
         }).toThrow();
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2015",
+        "target": "es2017",
         "declaration": true,
         "sourceMap": false,
         "outDir": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,10 +603,26 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.1.tgz#36a6acc93987adcf0ba50c66908bd0b70de8afea"
   integrity sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
 
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+
+"@jridgewell/trace-mapping@^0.3.14":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.13"
@@ -675,6 +691,32 @@
   dependencies:
     commander "*"
 
+"@types/eslint-scope@^3.7.3":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
+  integrity sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint@*":
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.6.tgz#7976f054c1bccfcf514bff0564c0c41df5c08207"
+  integrity sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+
+"@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
 "@types/event-stream@^3.3.34":
   version "3.3.34"
   resolved "https://registry.yarnpkg.com/@types/event-stream/-/event-stream-3.3.34.tgz#104bcedd5c61f90917b734bde04e61c6e64f03e1"
@@ -721,6 +763,11 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/json-schema@*", "@types/json-schema@^7.0.8":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -758,6 +805,137 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
+
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
+
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
+
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@xtuc/long" "4.2.2"
+
+"@xtuc/ieee754@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
+  integrity sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
+
+"@xtuc/long@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
+  integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
 JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -765,6 +943,31 @@ JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+acorn-import-assertions@^1.7.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
+  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
+
+acorn@^8.5.0, acorn@^8.7.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv@^6.12.5:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ansi-escapes@^4.2.1:
   version "4.3.1"
@@ -907,6 +1110,16 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browserslist@^4.14.5:
+  version "4.21.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
+
 browserslist@^4.20.2:
   version "4.20.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
@@ -957,6 +1170,11 @@ caniuse-lite@^1.0.30001332:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz#8a1e7fdc4db9c2ec79a05e9fd68eb93a761888bb"
   integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
 
+caniuse-lite@^1.0.30001400:
+  version "1.0.30001409"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz#6135da9dcab34cd9761d9cdb12a68e6740c5e96e"
+  integrity sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==
+
 chalk@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
@@ -986,6 +1204,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chrome-trace-event@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
+  integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1049,6 +1272,11 @@ commander@*, commander@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 compare-versions@^3.6.0:
   version "3.6.0"
@@ -1136,6 +1364,11 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.143.tgz#10f1bb595ad6cd893c05097039c685dcf5c8e30c"
   integrity sha512-2hIgvu0+pDfXIqmVmV5X6iwMjQ2KxDsWKwM+oI1fABEOy/Dqmll0QJRmIQ3rm+XaoUa/qKrmy5h7LSTFQ6Ldzg==
 
+electron-to-chromium@^1.4.251:
+  version "1.4.257"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz#895dc73c6bb58d1235dc80879ecbca0bcba96e2c"
+  integrity sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==
+
 emittery@^0.10.2:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.2.tgz#902eec8aedb8c41938c46e9385e9db7e03182933"
@@ -1153,12 +1386,25 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1175,10 +1421,35 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+eslint-scope@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -1197,6 +1468,11 @@ event-stream@3.3.4:
     split "0.3"
     stream-combiner "~0.0.4"
     through "~2.3.1"
+
+events@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@^4.0.0:
   version "4.0.3"
@@ -1243,6 +1519,11 @@ expect@^28.1.0:
     jest-matcher-utils "^28.1.0"
     jest-message-util "^28.1.0"
     jest-util "^28.1.0"
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1333,6 +1614,11 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -1362,7 +1648,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -1902,6 +2188,15 @@ jest-watcher@^28.1.0:
     jest-util "^28.1.0"
     string-length "^4.0.1"
 
+jest-worker@^27.4.5:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
+  integrity sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
 jest-worker@^28.1.0:
   version "28.1.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.0.tgz#ced54757a035e87591e1208253a6e3aac1a855e5"
@@ -1938,10 +2233,15 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-json-parse-even-better-errors@^2.3.0:
+json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json5@^2.2.1:
   version "2.2.1"
@@ -1967,6 +2267,11 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+loader-runner@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
+  integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -2036,6 +2341,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.27:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2074,6 +2391,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2083,6 +2405,11 @@ node-releases@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.5.tgz#280ed5bc3eba0d96ce44897d8aee478bfb3d9666"
   integrity sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
+
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -2300,6 +2627,18 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -2353,10 +2692,24 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+safe-buffer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+schema-utils@^3.1.0, schema-utils@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -2386,6 +2739,13 @@ semver@^7.3.5:
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
+
+serialize-javascript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2423,6 +2783,14 @@ source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -2547,6 +2915,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -2554,6 +2927,27 @@ terminal-link@^2.0.0:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
+
+terser-webpack-plugin@^5.1.3:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz#5590aec31aa3c6f771ce1b1acca60639eab3195c"
+  integrity sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.14"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    terser "^5.14.1"
+
+terser@^5.14.1:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.0.tgz#e16967894eeba6e1091509ec83f0c60e179f2425"
+  integrity sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -2620,6 +3014,21 @@ typescript@~4.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
+update-browserslist-db@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz#2924d3927367a38d5c555413a7ce138fc95fcb18"
+  integrity sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
 v8-to-istanbul@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz#be0dae58719fc53cb97e5c7ac1d7e6d4f5b19511"
@@ -2635,6 +3044,49 @@ walker@^1.0.7:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+watchpack@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack@^5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.7.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.10.0"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.4.0"
+    webpack-sources "^3.2.3"
 
 which-pm-runs@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
For very large builds, serializing the stats to JSON can take quite an extended time. Since the `wepback` done callback includes a `webpack.Stats` object that includes a `Compilation` with all the relevant information, this change allows developers to pass that `webpack.Stats` object instead of the serialized `webpack.StatsCompilation` JSON.