### PR TITLE
Fix `directParents` in bundle data

### DIFF
--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -1,5 +1,5 @@
 import { ModuleGraph, ModuleGraphNode } from '../../../types/BundleData';
-import { Stats } from '../../../types/Stats';
+import { Reason, Stats } from '../../../types/Stats';
 import { arrayUnion } from '../../../util/arrayUnion';
 import ModuleIdToNameMap from './ModuleIdToNameMap';
 import NamedChunkGroupLookupMap from '../NamedChunkGroupLookupMap';
@@ -40,13 +40,17 @@ export function processModule(
         return;
     }
 
-    const moduleReasons = isModule(module)
+    const moduleReasons: Pick<Reason, 'moduleName' | 'moduleId' | 'type'>[] = isModule(module)
         ? [...(compilation as Compilation).moduleGraph.getIncomingConnections(module as Module)]
-              .map(
-                  ({ dependency }) =>
-                      dependency && compilation.moduleGraph.getModule(dependency).identifier()
-              )
-              .filter(reason => !!reason)
+              .filter(({ dependency }) => !!dependency)
+              .map(({ dependency }) => {
+                  const depModule: Module = compilation.moduleGraph.getModule(dependency);
+                  return {
+                      moduleName: getModuleName(module, compilation),
+                      moduleId: depModule.id,
+                      type: dependency.type,
+                  };
+              })
         : module.reasons;
 
     // Precalculate named chunk groups since they are the same for all submodules

--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -46,8 +46,8 @@ export function processModule(
               .map(({ dependency }) => {
                   const depModule: Module = compilation.moduleGraph.getModule(dependency);
                   return {
-                      moduleName: getModuleName(module, compilation),
-                      moduleId: depModule.id,
+                      moduleName: getModuleName(depModule, compilation),
+                      moduleId: (compilation as Compilation).chunkGraph.getModuleId(depModule),
                       type: dependency.type,
                   };
               })

--- a/src/api/deriveBundleData/graph/processReasons.ts
+++ b/src/api/deriveBundleData/graph/processReasons.ts
@@ -1,7 +1,10 @@
 import { Reason } from '../../../types/Stats';
 import ModuleIdToNameMap from './ModuleIdToNameMap';
 
-export function processReasons(reasons: Reason[], moduleIdToNameMap: ModuleIdToNameMap) {
+export function processReasons(
+    reasons: Pick<Reason, 'moduleName' | 'moduleId' | 'type'>[],
+    moduleIdToNameMap: ModuleIdToNameMap
+) {
     const directParents = new Set<string>();
     const lazyParents = new Set<string>();
     let entryType: string | undefined = undefined;


### PR DESCRIPTION
I messed up the `reasons` in #70, and Typescript didn't save me from myself. This change fixes the `directParents` entries in the resulting graph when using a `StatsCompilation` object.