### PR TITLE
Fix parent names to not include "+ X modules"

### DIFF
--- a/src/types/StatsOrComiplationModule.ts
+++ b/src/types/StatsOrComiplationModule.ts
@@ -5,4 +5,5 @@ export type StatsOrComiplationModule =
     | StatsModule
     | (Module & {
           readableIdentifier(requestShortener: Compilation['requestShortener']): string;
+          modules?: Module[];
       });

--- a/src/util/getModuleName.ts
+++ b/src/util/getModuleName.ts
@@ -6,9 +6,8 @@ export function getModuleName(
     module: StatsOrComiplationModule,
     stats: Stats | Compilation
 ): string {
-    return 'readableIdentifier' in module
-        ? module.readableIdentifier((stats as Compilation).requestShortener)
-        : module.modules
-        ? module.modules[0].name
-        : module.name;
+    const rootModule = module.modules?.[0] ?? module;
+    return 'readableIdentifier' in rootModule
+        ? rootModule.readableIdentifier((stats as Compilation).requestShortener)
+        : rootModule.name;
 }


### PR DESCRIPTION
This fixes a bug in #74, where the names in `"parents"` or `"directParents"` could include names of the format `"<module name> + X modules"`