### PR TITLE
Fix parent module derivation when using Compilation stats

### DIFF
--- a/src/api/deriveBundleData/graph/processReasons.ts
+++ b/src/api/deriveBundleData/graph/processReasons.ts
@@ -19,6 +19,9 @@ export function processReasons(
 
             // There is no parent module in this case, so just move on
             continue;
+        } else if (!reason.moduleId && !reason.moduleName) {
+            // Some reasons are introduced by loaders and don't indicate a parent module
+            continue;
         }
 
         // If moduleId is present, use that to look up the module name.  (The moduleName


### PR DESCRIPTION
When deriving `reasons` from the Compilation stats, we should be calling `getParentModule`, not `getModule`.

Once I fixed this it exposed another issue where some reasons don't _have_ a parent module.  (Seems like these get introduced by some style-related loaders.)  These aren't really part of the module graph that we're interested in, so I added a check to ignore them.