### PR TITLE
Fix directParents and lazyParents when merging module graph nodes

### DIFF
--- a/src/api/deriveBundleData/graph/deriveGraph.ts
+++ b/src/api/deriveBundleData/graph/deriveGraph.ts
@@ -111,6 +111,8 @@ function addModuleToGraph(graph: ModuleGraph, moduleNode: ModuleGraphNode) {
     if (graph[moduleNode.name]) {
         const graphNode = graph[moduleNode.name];
         graphNode.parents = arrayUnion(graphNode.parents, moduleNode.parents);
+        graphNode.directParents = arrayUnion(graphNode.directParents, moduleNode.directParents);
+        graphNode.lazyParents = arrayUnion(graphNode.lazyParents, moduleNode.lazyParents);
         graphNode.namedChunkGroups = arrayUnion(
             graphNode.namedChunkGroups,
             moduleNode.namedChunkGroups


### PR DESCRIPTION
The `directParents` and `lazyParents` edges need to be merged when merging a duplicate module node, just like the `parents` edges.